### PR TITLE
Fix Windows inst. to launch app in the background

### DIFF
--- a/windows/mudlet-bitrock-project.xml
+++ b/windows/mudlet-bitrock-project.xml
@@ -412,7 +412,7 @@
     <finalPageActionList>
         <runProgram>
             <program>${installdir}/mudlet.exe</program>
-            <programArguments></programArguments>
+            <programArguments>&amp;</programArguments>
             <progressText>Run ${project.fullName} now</progressText>
             <ruleList>
                 <platformTest>


### PR DESCRIPTION
Without this, if you select 'Run Mudlet now' option in the installer, you can't delete the installer file.