### PR TITLE
Use a more general symlink for Qt

### DIFF
--- a/osx/build-and-make-installer.sh
+++ b/osx/build-and-make-installer.sh
@@ -32,7 +32,7 @@ CI/travis.osx.before_install.sh
 CI/travis.osx.install.sh
 
 # Setup PATH to find qmake
-PATH=/usr/local/opt/qt5/bin:$PATH
+PATH=/usr/local/opt/qt/bin:$PATH
 
 # Add commit information to version and extract version info itself
 cd src/

--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -20,7 +20,7 @@ done
 shift $((OPTIND-1))
 
 # set path to find macdeployqt
-PATH=/usr/local/opt/qt5/bin:$PATH
+PATH=/usr/local/opt/qt/bin:$PATH
 
 cd source/build
 
@@ -60,13 +60,13 @@ fi
 macdeployqt "${app}"
 
 # fix unfinished deployment of macdeployqt
-python macdeployqtfix.py "${app}/Contents/MacOS/Mudlet" "/usr/local/Cellar/qt5/5.8.0_1/"
+python macdeployqtfix.py "${app}/Contents/MacOS/Mudlet" "/usr/local/opt/qt/bin"
 
 # Bundle in dynamically loaded libraries
 cp "${HOME}/.luarocks/lib/lua/5.1/lfs.so" "${app}/Contents/MacOS"
 cp "${HOME}/.luarocks/lib/lua/5.1/rex_pcre.so" "${app}/Contents/MacOS"
 # rex_pcre has to be adjusted to load libcpre from the same location
-python macdeployqtfix.py "${app}/Contents/MacOS/rex_pcre.so" "/usr/local/Cellar/qt5/5.8.0_1/"
+python macdeployqtfix.py "${app}/Contents/MacOS/rex_pcre.so" "/usr/local/opt/qt/bin"
 cp -r "${HOME}/.luarocks/lib/lua/5.1/luasql" "${app}/Contents/MacOS"
 
 # Edit some nice plist entries, don't fail if entries already exist


### PR DESCRIPTION
The old pathes depended too much on Qt versions. The current one will always use the same Qt installation.