### PR TITLE
Use patched appdmg for all creating macOS versions

### DIFF
--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -49,12 +49,7 @@ luarocks-5.1 --local install LuaFileSystem
 luarocks-5.1 --local install lrexlib-pcre
 luarocks-5.1 --local install LuaSQL-SQLite3 SQLITE_DIR=/usr/local/opt/sqlite
 
-macOsVersion="$(sw_vers -productVersion)"
-if [ "${macOsVersion}" = "10.12" ] || [ "${macOsVersion}" = "10.12.1" ] || [ "${macOsVersion}" = "10.12.2" ]; then
-  npm install -g ArmorText/node-appdmg#feature/background-hack
-else
-  npm install -g appdmg
-fi
+npm install -g ArmorText/node-appdmg#feature/background-hack
 
 # Bundle in Qt libraries
 macdeployqt "${app}"


### PR DESCRIPTION
It seems that the bug with missing backgrounds does not care about the macOS version when creating. Instead the version when opening the created dmg plays a role. This is why we now always use the patched appdmg version.