### PR TITLE
Use BUILD environment variable to set version

### DIFF
--- a/osx/build-and-make-installer.sh
+++ b/osx/build-and-make-installer.sh
@@ -39,7 +39,8 @@ cd src/
 # find out if we do a dev or a release build
 dev=$(perl -lne 'print $1 if /^BUILD = (.*)$/' < src.pro)
 if [ ! -z "${dev}" ]; then
-  perl -pi -e "s/BUILD = -dev.*$/BUILD = -dev-$commit/" src.pro
+  BUILD="-dev-$commit"
+  export BUILD
 fi
 version=$(perl -lne 'print $1 if /^VERSION = (.+)/' < src.pro)
 cd ..
@@ -55,7 +56,7 @@ make -j "$(sysctl -n hw.ncpu)"
 
 # determine target app name
 if [ ! -z "${dev}" ]; then
-  app="Mudlet-${version}-dev-${commit}.app"
+  app="Mudlet-${version}${BUILD}.app"
   # Rename app according to version
   mv Mudlet.app "${app}"
 else

--- a/osx/build-and-make-installer.sh
+++ b/osx/build-and-make-installer.sh
@@ -39,8 +39,8 @@ cd src/
 # find out if we do a dev or a release build
 dev=$(perl -lne 'print $1 if /^BUILD = (.*)$/' < src.pro)
 if [ ! -z "${dev}" ]; then
-  BUILD="-dev-$commit"
-  export BUILD
+  MUDLET_VERSION_BUILD="-dev-$commit"
+  export MUDLET_VERSION_BUILD
 fi
 version=$(perl -lne 'print $1 if /^VERSION = (.+)/' < src.pro)
 cd ..


### PR DESCRIPTION
This allows avoiding modifying the Makefile during the build process and keeps
the source directory in a clean state.

This needs Mudlet/Mudlet#958 to work