### PR TITLE
Adapt generic linux installer generation

### DIFF
--- a/generic-linux/README.md
+++ b/generic-linux/README.md
@@ -1,0 +1,52 @@
+The OS X installer generation
+=============================
+
+The directory
+-------------
+
+This directory contains all files needed to create the generic linux APpImage. It is home to two helper scripts `build-and-make-installer.sh`, which runs the full build and generation process, as well as `make-installer.sh`, which is the isolated generation process.
+
+Prerequisites
+-------------
+
+The script expects all dependencies to be installed (for a current list have a look at the `.travis.yml` and `CI/travis.linux.install.sh` of the main project). It will only download the `linuxdeployqt.AppImage` it uses.
+
+How to generate the installer
+-----------------------------
+
+### Building and generating in one step ###
+
+Usage:
+```bash
+$ ./build-and-make-installer.sh [<commit-ish>]
+```
+
+Example:
+```bash
+$ ./build-and-make-installer.sh development
+```
+
+The script `build-and-make-installer.sh` installs build dependencies, clones  the git repository of Mudlet, checks the specified `commit-ish`out of the repository and starts building Mudlet. This may take a while. After the build is done, it hands control to the `make-installer.sh` script automatically.
+
+If an `source` subdirectory exists, `commit-ish` is optional. If it exists, the currently checked out branch is used to build, otherwise the Mudlet sources will be cloned into the `source` subdirectory and `commit-ish` will be checked out.
+
+### Generating the installer only ###
+
+Usage:
+```bash
+$ ./make-installer.sh [-r] <version>
+```
+
+Examples:
+```bash
+$ ./make-installer.sh dev-01923abc
+$ ./make-installer.sh -r 3.0.0
+```
+
+Prerequisites:
+
+- A pre-build `mudlet` binary in `./source/build/`, e.g. the output of the Travis build process or the result of the `build-and-make-installer.sh` before it hands control to this script.
+
+The script `make-installer.sh` copies the runtime dependencies as well as Qt required dynamically linked libraries into the `./build` directory, adapts search pathes and finally bundles it all up into a single `.AppImage` according to the passed version.
+
+The optional argument `-r` sets a release version. This will make the output AppImage to be named `Mudlet.AppImage` as opposed to development versions, where the binary is called `Mudlet-<version>.AppImage`.

--- a/generic-linux/build-and-make-installer.sh
+++ b/generic-linux/build-and-make-installer.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+
+# abort script if any command fails
+set -e
+
+# extract program name for message
+pgm=$(basename "$0")
+
+# Retrieve latest source code, keep history as it's useful to edit sometimes
+# if it's already there, keep it as is
+if [ ! -d "source" ]; then
+  # check command line option for commit-ish that should be checked out
+  commitish="$1"
+  if [ -z "$commitish" ]; then
+    echo "No 'source' folder exists and no commit-ish given."
+    echo "Usage: $pgm <commit-ish>"
+    exit 2
+  fi
+
+  git clone --recursive https://github.com/Mudlet/Mudlet.git source
+
+  # Switch to $commitish
+  (cd source && git checkout "${commitish}")
+fi
+
+# set the commit ID so the build can reference it later
+cd source
+commit=$(git rev-parse --short HEAD)
+
+# linux assumes compile time dependencies are installed to make this
+# (hopefully) distribution independent
+
+# Add commit information to version and extract version info itself
+cd src/
+# find out if we do a dev or a release build
+dev=$(perl -lne 'print $1 if /^BUILD = (.*)$/' < src.pro)
+if [ ! -z "${dev}" ]; then
+  MUDLET_VERSION_BUILD="-dev-$commit"
+  export MUDLET_VERSION_BUILD
+fi
+version=$(perl -lne 'print $1 if /^VERSION = (.+)/' < src.pro)
+cd ..
+
+mkdir -p build
+cd build/
+
+# Compile using all available cores
+qmake ../src/src.pro
+make -j "$(nproc)"
+
+# now run the actual installer creation script
+cd ../..
+if [ ! -z "${dev}" ]; then
+  ./make-installer.sh "${version}${MUDLET_VERSION_BUILD}"
+else
+  ./make-installer.sh -r "${version}"
+fi

--- a/generic-linux/make-installer.sh
+++ b/generic-linux/make-installer.sh
@@ -54,13 +54,19 @@ perl -pi -e "s/1.0/${version}/g" build/mudlet.desktop
 mkdir -p build/lib/luasql
 for lib in lfs rex_pcre luasql/sqlite3 zip lua-utf8
 do
+  found=0
   for path in $(lua -e "print(package.cpath)" | tr ";" "\n")
   do
     changed_path=${path/\?/${lib}};
     if [ -e "${changed_path}" ]; then
       cp -rL "${changed_path}" build/lib/${lib}.so
+      found=1
     fi
   done
+  if [ "${found}" -ne "1" ]; then
+    echo "Missing dependency ${lib}, aborting."
+    exit 1
+  fi
 done
 
 # copy in files ignored (?) by linuxdeployqt

--- a/generic-linux/make-installer.sh
+++ b/generic-linux/make-installer.sh
@@ -71,7 +71,7 @@ done
 
 # copy in files ignored (?) by linuxdeployqt
 cp "$(ldd build/lib/rex_pcre.so | cut -d ' ' -f 3 | grep 'libpcre')" build/lib
-cp "$(ldd build/lib/zip.so | cut -d ' ' -f 3 | grep 'libz')" build/lib
+cp "$(ldd build/lib/zip.so | cut -d ' ' -f 3 | grep 'libz.so')" build/lib
 
 echo "Generating AppImage"
 ./linuxdeployqt.AppImage ./build/mudlet -appimage -executable=build/lib/rex_pcre.so -executable=build/lib/zip.so -executable=build/lib/luasql/sqlite3.so

--- a/generic-linux/make-installer.sh
+++ b/generic-linux/make-installer.sh
@@ -3,72 +3,37 @@
 # abort script if any command fails
 set -e
 
-START_DIRECTORY=$(pwd)
+release=""
+
+# find out if we do a release build
+while getopts ":r:" o; do
+  if [ "${o}" = "r" ]; then
+    release="${OPTARG}"
+    version="${OPTARG}"
+  else
+    echo "Unknown option -${o}"
+    exit 1
+  fi
+done
+shift $((OPTIND-1))
+if [ -z "${release}" ]; then
+  version="${1}"
+fi
 
 # setup linuxdeployqt binary if not found
-if [[ ! -e linuxdeployqt.AppImage ]]; then
-  if [ "$(getconf LONG_BIT)" = "64" ]
-  then
+if [ "$(getconf LONG_BIT)" = "64" ]; then
+  if [[ ! -e linuxdeployqt.AppImage ]]; then
       # download prepackaged linuxdeployqt. Doesn't seem to have a "latest" url yet
       echo "linuxdeployqt not found - downloading one."
       wget -O linuxdeployqt.AppImage https://github.com/probonopd/linuxdeployqt/releases/download/continuous/linuxdeployqt-continuous-x86_64.AppImage
       chmod +x linuxdeployqt.AppImage
-  else
-    echo "linuxdeployqt not found - making one."
-    rm -rf patchelf/ linuxdeployqt/
-    sudo rm -f /usr/local/bin/appimagetool
-
-    git clone --depth=1 https://github.com/NixOS/patchelf.git
-    cd patchelf
-    bash ./bootstrap.sh
-    ./configure
-    make -j "$(nproc)"
-    sudo make install
-
-    cd "${START_DIRECTORY}"
-    sudo wget -c "https://github.com/probonopd/AppImageKit/releases/download/continuous/appimagetool-i686.AppImage" -O /usr/local/bin/appimagetool
-    sudo chmod a+x /usr/local/bin/appimagetool
-
-    git clone --depth=50 https://github.com/probonopd/linuxdeployqt.git
-    cd linuxdeployqt/
-    # build currently broken, use latest that works
-    git checkout c21b17174de603e6be14ef719c20101d1ccfb87e
-    qmake linuxdeployqt.pro
-    make -j "$(nproc)"
-
-    mkdir -p linuxdeployqt.AppDir/usr/bin/
-    cp /usr/local/bin/patchelf linuxdeployqt.AppDir/usr/bin/
-    cp /usr/local/bin/appimagetool linuxdeployqt.AppDir/usr/bin/
-    find linuxdeployqt.AppDir/
-    export VERSION=continuous
-    cp ./linuxdeployqt/linuxdeployqt linuxdeployqt.AppDir/usr/bin/
-    ./linuxdeployqt/linuxdeployqt linuxdeployqt.AppDir/linuxdeployqt.desktop -appimage
-    cp linuxdeployqt-continuous-Intel_80386.AppImage "${START_DIRECTORY}/linuxdeployqt.AppImage"
   fi
+else
+  echo "32bit Linux is currently not supported."
+  exit 2
 fi
 
-# Retrieve latest source code, keep history as it's useful to edit sometimes
-if [ ! -d "source" ]; then
-  git clone https://github.com/Mudlet/Mudlet.git source
-fi
-
-# In case Mudlet source already exists, update it
-cd "${START_DIRECTORY}"
-cd source/
-git pull
-
-# Switch to release banrch
-# git fetch
-# git checkout release_30
-
-cd src/
-
-# Compile using all available cores
-qmake
-make -j "$(nproc)"
-
-# go up to the root folder and clean up the build/ folder
-cd ../../
+# clean up the build/ folder
 rm -rf build/
 mkdir build
 
@@ -76,125 +41,38 @@ mkdir build
 rm -f Mudlet*.AppImage
 
 # move the binary up to the build folder
-cp source/src/mudlet build/
+cp source/build/mudlet build/
 # get mudlet-lua in there as well so linuxdeployqt bundles it
 cp -rf source/src/mudlet-lua build/
 # and the .desktop file so linuxdeployqt can pilfer it for info
 cp source/mudlet{.desktop,.png,.svg} build/
 
-# first go at generation
-echo "Generating AppImage for the first time"
-./linuxdeployqt.AppImage ./build/mudlet -appimage
+perl -pi -e "s/1.0/${version}/g" build/mudlet.desktop
 
 # now copy Lua modules we need in
 # this should be improved not to be hardcoded
-if [ "$(getconf LONG_BIT)" = "64" ]
-    then
-    cp /usr/lib/x86_64-linux-gnu/lua/5.1/lfs.so                            ./build/lib
-    cp /usr/lib/x86_64-linux-gnu/lua/5.1/rex_pcre.so                       ./build/lib
-    mkdir                                                                  ./build/lib/luasql
-    cp /usr/lib/x86_64-linux-gnu/lua/5.1/luasql/sqlite3.so                 ./build/lib/luasql
-    cp /usr/lib/x86_64-linux-gnu/lua/5.1/zip.so                            ./build/lib
-    # patch zip.so so it loads libzzip, disable shellcheck as we really don't want expansion
-    # shellcheck disable=SC2016
-    patchelf --set-rpath '$ORIGIN' ./build/lib/zip.so
-    cp /usr/lib/x86_64-linux-gnu/libzzip-0.so.13                           ./build/lib
-    # mp3 support for sounds 
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstflump3dec.so         ./build/lib
-    cp /lib/x86_64-linux-gnu/libz.so.1                                     ./build/lib
-    cp /lib/x86_64-linux-gnu/libpcre.so.3                                  ./build/lib
-     
-    # gstreamer bulk include. This needs to have the video stuff pruned... 
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstadder.so             ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstalsa.so              ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstapp.so               ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstaudioconvert.so      ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstaudiorate.so         ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstaudioresample.so     ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstaudiotestsrc.so      ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstcdparanoia.so        ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstcoreelements.so      ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstcoreelements.so      ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstcoreindexers.so      ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstdecodebin.so         ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstdecodebin2.so        ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstencodebin.so         ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstffmpegcolorspace.so  ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstflump3dec.so         ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstgdp.so               ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstgio.so               ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstlibvisual.so         ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstnice010.so           ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstogg.so               ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstpango.so             ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstplaybin.so           ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstplaybin.so           ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstpulse.so             ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstsubparse.so          ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgsttcp.so               ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgsttheora.so            ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgsttypefindfunctions.so ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstvideorate.so         ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstvideoscale.so        ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstvideotestsrc.so      ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstvolume.so            ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstvorbis.so            ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstximagesink.so        ./build/lib
-    # cp /usr/lib/x86_64-linux-gnu/gstreamer-0.10/libgstxvimagesink.so       ./build/lib
-else
-  cp /usr/lib/i386-linux-gnu/lua/5.1/lfs.so                            ./build/lib
-  cp /usr/lib/i386-linux-gnu/lua/5.1/rex_pcre.so                       ./build/lib
-  mkdir                                                                ./build/lib/luasql
-  cp /usr/lib/i386-linux-gnu/lua/5.1/luasql/sqlite3.so                 ./build/lib/luasql
-  cp /usr/lib/i386-linux-gnu/lua/5.1/zip.so                            ./build/lib
-  # patch zip.so so it loads libzzip, disable shellcheck as we really don't want expansion
-  # shellcheck disable=SC2016
-  patchelf --set-rpath '$ORIGIN' ./build/lib/zip.so
-  cp /usr/lib/i386-linux-gnu/libzzip-0.so.13                           ./build/lib
-  # mp3 support for sounds 
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstflump3dec.so         ./build/lib
-  cp /lib/i386-linux-gnu/libz.so.1                                     ./build/lib
-  cp /lib/i386-linux-gnu/libpcre.so.3                                  ./build/lib
-   
-  # gstreamer bulk include. This needs to have the video stuff pruned. ..
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstadder.so             ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstalsa.so              ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstapp.so               ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstaudioconvert.so      ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstaudiorate.so         ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstaudioresample.so     ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstaudiotestsrc.so      ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstcdparanoia.so        ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstcoreelements.so      ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstcoreelements.so      ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstcoreindexers.so      ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstdecodebin.so         ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstdecodebin2.so        ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstencodebin.so         ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstffmpegcolorspace.so  ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstflump3dec.so         ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstgdp.so               ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstgio.so               ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstlibvisual.so         ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstnice010.so           ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstogg.so               ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstpango.so             ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstplaybin.so           ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstplaybin.so           ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstpulse.so             ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstsubparse.so          ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgsttcp.so               ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgsttheora.so            ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgsttypefindfunctions.so ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstvideorate.so         ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstvideoscale.so        ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstvideotestsrc.so      ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstvolume.so            ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstvorbis.so            ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstximagesink.so        ./build/lib
-  # cp /usr/lib/i386-linux-gnu/gstreamer-0.10/libgstxvimagesink.so       ./build/lib 
-fi
+mkdir -p build/lib/luasql
+for lib in lfs rex_pcre luasql/sqlite3 zip lua-utf8
+do
+  for path in $(lua -e "print(package.cpath)" | tr ";" "\n")
+  do
+    changed_path=${path/\?/${lib}};
+    if [ -e "${changed_path}" ]; then
+      cp -rL "${changed_path}" build/lib/${lib}.so
+    fi
+  done
+done
 
-echo "Regenerating AppImage to include Lua C and GStreamer modules"
-# and regenerate (https://github.com/probonopd/linuxdeployqt/issues/67#issuecomment-279211530)
-./linuxdeployqt.AppImage ./build/mudlet -appimage
+# copy in files ignored (?) by linuxdeployqt
+cp "$(ldd build/lib/rex_pcre.so | cut -d ' ' -f 3 | grep 'libpcre')" build/lib
+cp "$(ldd build/lib/zip.so | cut -d ' ' -f 3 | grep 'libz')" build/lib
+
+echo "Generating AppImage"
+./linuxdeployqt.AppImage ./build/mudlet -appimage -executable=build/lib/rex_pcre.so -executable=build/lib/zip.so -executable=build/lib/luasql/sqlite3.so
+
+if [ -z "${release}" ]; then
+  output_name="Mudlet-${version}"
+else
+  output_name="Mudlet"
+fi
+mv Mudlet*.AppImage "$output_name.AppImage"


### PR DESCRIPTION
The process is now designed to be similar to the macOS process. A few
differences had to be done, but those are trivial.

I am missing the readme file still, but otherwise, this should work. It is tested, though I noticed we have to use a gcc as low as possible, otherwise older distros will have problems supplying the correct version of stdc++ libraries.