### PR TITLE
Add Sparkle default options

### DIFF
--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -80,6 +80,12 @@ fi
 /usr/libexec/PlistBuddy -c "Add CFBundleShortVersionString string ${shortVersion}" "${app}/Contents/Info.plist" || true
 /usr/libexec/PlistBuddy -c "Add CFBundleVersion string ${version}" "${app}/Contents/Info.plist" || true
 
+# Sparkle settings, see https://sparkle-project.org/documentation/customization/#infoplist-settings
+/usr/libexec/PlistBuddy -c "Add SUFeedURL string https://feeds.dblsqd.com/MKMMR7HNSP65PquQQbiDIw/release/mac/x86_64/appcast" "${app}/Contents/Info.plist" || true
+/usr/libexec/PlistBuddy -c "Add SUEnableAutomaticChecks bool true" "${app}/Contents/Info.plist" || true
+/usr/libexec/PlistBuddy -c "Add SUAllowsAutomaticUpdates bool true" "${app}/Contents/Info.plist" || true
+/usr/libexec/PlistBuddy -c "Add SUAutomaticallyUpdate bool true" "${app}/Contents/Info.plist" || true
+
 # Generate final .dmg
 cd ../..
 rm -f ~/Desktop/Mudlet*.dmg


### PR DESCRIPTION
Sparkle requires some options to be set in the plist file in order to work.

We should be OK on merging this in now as they won't affect existing builds, and it's necessary to be able to test https://github.com/Mudlet/Mudlet/pull/1318 properly.