### PR TITLE
Remove unnecessary (and possibly dangerous) bundled files

### DIFF
--- a/generic-linux/make-installer.sh
+++ b/generic-linux/make-installer.sh
@@ -69,10 +69,6 @@ do
   fi
 done
 
-# copy in files ignored (?) by linuxdeployqt
-cp "$(ldd build/lib/rex_pcre.so | cut -d ' ' -f 3 | grep 'libpcre')" build/lib
-cp "$(ldd build/lib/zip.so | cut -d ' ' -f 3 | grep 'libz.so')" build/lib
-
 # extract linuxdeployqt since some environments (like travis) don't allow FUSE
 ./linuxdeployqt.AppImage --appimage-extract
 


### PR DESCRIPTION
See https://github.com/probonopd/linuxdeployqt/issues/269 and
https://github.com/AppImage/AppImages/blob/master/excludelist about it.

It was confirmed to be working on Ubuntu 17.10, Ubuntu Mate 17.10, and Fedora 26