### PR TITLE
Add alias expansion to osx/make-installer.sh

### DIFF
--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -2,6 +2,7 @@
 
 # abort script if any command fails
 set -e
+shopt -s expand_aliases
 
 # extract program name for message
 pgm=$(basename "$0")


### PR DESCRIPTION
This is needed to use the created luarocks-5.1 alias.