### PR TITLE
Fix node.js to LTS version (8.12)

### DIFF
--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -36,7 +36,7 @@ fi
 
 # install installer dependencies
 brew update
-BREWS="sqlite3 lua@5.1 node wget luarocks"
+BREWS="sqlite3 lua@5.1 node@8 wget luarocks"
 for i in $BREWS; do
   brew outdated | grep -q "$i" && brew upgrade "$i"
 done


### PR DESCRIPTION
The current node.js version (10.12) is not provided as a bottle for 10.11 (our supported macOS version) anymore, so it needs to be compiled, which times out.