### PR TITLE
Testing: make the {mac|linux}deployqt utilities more verbose

### DIFF
--- a/generic-linux/make-installer.sh
+++ b/generic-linux/make-installer.sh
@@ -75,8 +75,13 @@ done
 # extract linuxdeployqt since some environments (like travis) don't allow FUSE
 ./linuxdeployqt.AppImage --appimage-extract
 
+echo "Path is: "${PATH}"
+
+echo "Checking qmake -v to determine Qt version used by linuxdeployqt:"
+qmake -v
+
 echo "Generating AppImage"
-./squashfs-root/AppRun ./build/mudlet -appimage -executable=build/lib/rex_pcre.so -executable=build/lib/zip.so -executable=build/lib/luasql/sqlite3.so -executable=build/lib/yajl.so -extra-plugins=texttospeech/libqttexttospeech_flite.so,texttospeech/libqtexttospeech_speechd.so,platforminputcontexts/libcomposeplatforminputcontextplugin.so,platforminputcontexts/libibusplatforminputcontextplugin.so
+./squashfs-root/AppRun ./build/mudlet -verbose=2 -appimage -executable=build/lib/rex_pcre.so -executable=build/lib/zip.so -executable=build/lib/luasql/sqlite3.so -executable=build/lib/yajl.so -extra-plugins=texttospeech/libqttexttospeech_flite.so,texttospeech/libqtexttospeech_speechd.so,platforminputcontexts/libcomposeplatforminputcontextplugin.so,platforminputcontexts/libibusplatforminputcontextplugin.so
 
 
 # clean up extracted appimage

--- a/generic-linux/make-installer.sh
+++ b/generic-linux/make-installer.sh
@@ -75,7 +75,7 @@ done
 # extract linuxdeployqt since some environments (like travis) don't allow FUSE
 ./linuxdeployqt.AppImage --appimage-extract
 
-echo "Path is: "${PATH}"
+echo "Path is: ${PATH}"
 
 echo "Checking qmake -v to determine Qt version used by linuxdeployqt:"
 qmake -v

--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -60,11 +60,17 @@ luarocks-5.1 --local install lua-yajl
 PATH=/usr/local/bin:$PATH
 npm install -g appdmg
 
+echo "Path is: ${PATH}"
+
+echo "Checking qmake -v to determine Qt version used by macdeployqt:"
+qmake -v
+
+echo "Generating AppImage"
 # Bundle in Qt libraries
-macdeployqt "${app}"
+macdeployqt "${app}" -verbose=2
 
 # fix unfinished deployment of macdeployqt
-python macdeployqtfix.py "${app}/Contents/MacOS/Mudlet" "/usr/local/opt/qt/bin"
+python macdeployqtfix.py --verbose "${app}/Contents/MacOS/Mudlet" "/usr/local/opt/qt/bin"
 
 # Bundle in dynamically loaded libraries
 cp "${HOME}/.luarocks/lib/lua/5.1/lfs.so" "${app}/Contents/MacOS"


### PR DESCRIPTION
This is so that I can try and debug what is going on with https://github.com/Mudlet/Mudlet/pull/2729 where the Linux case does not appear to be including the Qt libraries translation files...

Signed-off-by: Stephen Lyons <slysven@virginmedia.com>