### PR TITLE
Avoid signing sparkle autoupdater

### DIFF
--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -122,7 +122,6 @@ fi
 # Sign everything now that we're done modifying contents of the .app file
 # Keychain is already setup in travis.osx.after_success.sh for us
 if [ -n "$IDENTITY" ] && security find-identity | grep -q "$IDENTITY"; then
-  codesign --deep -s "$IDENTITY" "${app}/Contents/Frameworks/Sparkle.framework/Resources/Autoupdate.app/"
   codesign --deep -s "$IDENTITY" "${app}"
 fi
 


### PR DESCRIPTION
The autoupdater is signed lately, which makes codesing abort. Even better for
us, since we don't need to sign foreign app bundles.