### PR TITLE
Make the AppImage generation independent of the used build system

### DIFF
--- a/generic-linux/make-installer.sh
+++ b/generic-linux/make-installer.sh
@@ -40,8 +40,9 @@ mkdir build
 # delete previous appimage as well since we need to regenerate it twice
 rm -f Mudlet*.AppImage
 
-# move the binary up to the build folder
-cp source/build/mudlet build/
+# move the binary up to the build folder (they differ between qmake and cmake,
+# so we use find to find the binary
+find source/build/ -iname mudlet -type f -exec cp '{}' build/ \;
 # get mudlet-lua in there as well so linuxdeployqt bundles it
 cp -rf source/src/mudlet-lua build/
 # and the dictionary files in case the user system doesn't have them (at a known


### PR DESCRIPTION
Both qmake and cmake use a different folder layout for their output files. To
make sure the script finds both versions, we use a find command now to copy the
mudlet binary.