### PR TITLE
Make appimage generation more CI system independent

### DIFF
--- a/generic-linux/make-installer.sh
+++ b/generic-linux/make-installer.sh
@@ -85,7 +85,7 @@ done
 # into the Qt for /opt package directory
 if [ -n "${QTDIR}" ]; then
   sudo cp /usr/lib/x86_64-linux-gnu/qt5/plugins/platforminputcontexts/libfcitxplatforminputcontextplugin.so \
-          ${QTDIR}/plugins/platforminputcontexts/libfcitxplatforminputcontextplugin.so || exit
+          "${QTDIR}/plugins/platforminputcontexts/libfcitxplatforminputcontextplugin.so" || exit
 fi
 
 # Bundle libssl.so so Mudlet works on platforms that only distribute

--- a/generic-linux/make-installer.sh
+++ b/generic-linux/make-installer.sh
@@ -89,9 +89,13 @@ sudo cp /usr/lib/x86_64-linux-gnu/qt5/plugins/platforminputcontexts/libfcitxplat
 # Bundle libssl.so so Mudlet works on platforms that only distribute
 # OpenSSL 1.1
 cp -L /usr/lib/x86_64-linux-gnu/libssl.so* \
-      build/lib/
+      build/lib/ || true
 cp -L /lib/x86_64-linux-gnu/libssl.so* \
-      build/lib/
+      build/lib/ || true
+if [ -z "$(ls build/lib/libssl.so*)" ]; then
+  echo "No OpenSSL libraries to copy found. Aborting..."
+  exit 1
+fi
 
 echo "Generating AppImage"
 ./squashfs-root/AppRun ./build/mudlet -appimage \

--- a/generic-linux/make-installer.sh
+++ b/generic-linux/make-installer.sh
@@ -81,10 +81,12 @@ done
 # extract linuxdeployqt since some environments (like travis) don't allow FUSE
 ./linuxdeployqt.AppImage --appimage-extract
 
-# a hack to get the Chinese input text plugin for Qt from the Ubuntu package into a location
-# linuxdeployqt will understand
-sudo cp /usr/lib/x86_64-linux-gnu/qt5/plugins/platforminputcontexts/libfcitxplatforminputcontextplugin.so \
-        /opt/qt512/plugins/platforminputcontexts/libfcitxplatforminputcontextplugin.so || exit
+# a hack to get the Chinese input text plugin for Qt from the Ubuntu package
+# into the Qt for /opt package directory
+if [ -n "${QTDIR}" ]; then
+  sudo cp /usr/lib/x86_64-linux-gnu/qt5/plugins/platforminputcontexts/libfcitxplatforminputcontextplugin.so \
+          ${QTDIR}/plugins/platforminputcontexts/libfcitxplatforminputcontextplugin.so || exit
+fi
 
 # Bundle libssl.so so Mudlet works on platforms that only distribute
 # OpenSSL 1.1


### PR DESCRIPTION
Some parts were pretty build-system-specific, which I tried to make more generic. This will probably need more tweaks once we support appimages for raspberry pi.