### PR TITLE
Temporary patch: install cjson instead of yajl when USE_CJSON is set

### DIFF
--- a/generic-linux/make-installer.sh
+++ b/generic-linux/make-installer.sh
@@ -69,7 +69,15 @@ mkdir -p build/lib/luasql
 
 cp source/3rdparty/discord/rpc/lib/libdiscord-rpc.so build/lib/
 
-for lib in lfs rex_pcre luasql/sqlite3 zip lua-utf8 yajl
+if [ "${USE_CJSON}" = "Y" ] ; then
+  yajl=
+  yajl_lib=
+else
+  yajl=yajl
+  yajl_lib=-executable=build/lib/yajl.so
+fi
+
+for lib in lfs rex_pcre luasql/sqlite3 zip lua-utf8 $yajl
 do
   found=0
   for path in $(lua -e "print(package.cpath)" | tr ";" "\n")
@@ -110,7 +118,7 @@ fi
 echo "Generating AppImage"
 ./squashfs-root/AppRun ./build/mudlet -appimage \
   -executable=build/lib/rex_pcre.so -executable=build/lib/zip.so \
-  -executable=build/lib/luasql/sqlite3.so -executable=build/lib/yajl.so \
+  -executable=build/lib/luasql/sqlite3.so $yajl_lib \
   -executable=build/lib/libssl.so.1.1 \
   -executable=build/lib/libssl.so.1.0.0 \
   -extra-plugins=texttospeech/libqttexttospeech_flite.so,texttospeech/libqttexttospeech_speechd.so,platforminputcontexts/libcomposeplatforminputcontextplugin.so,platforminputcontexts/libibusplatforminputcontextplugin.so,platforminputcontexts/libfcitxplatforminputcontextplugin.so

--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -66,7 +66,11 @@ luarocks-5.1 --local install lrexlib-pcre
 luarocks-5.1 --local install LuaSQL-SQLite3 SQLITE_DIR=/usr/local/opt/sqlite
 # Although it is called luautf8 here it builds a file called lua-utf8.so:
 luarocks-5.1 --local install luautf8
-luarocks-5.1 --local install lua-yajl
+if [ "${USE_CJSON}" = "Y" ] ; then
+  luarocks-5.1 --local install lua-cmake
+else
+  luarocks-5.1 --local install lua-yajl
+fi
 # This is the Brimworks one (same as lua-yajl) note the hyphen, the one without
 # is the Kelper project one which has the, recently (2020), troublesome
 # dependency on zziplib (libzzip), however to avoid clashes in the field
@@ -125,9 +129,11 @@ if [ "${LCF_NAME}" != "lcf" ]; then
   mv "${app}/Contents/MacOS/${LCF_NAME}" "${app}/Contents/MacOS/lcf"
 fi
 
-cp "${HOME}/.luarocks/lib/lua/5.1/yajl.so" "${app}/Contents/MacOS"
-# yajl has to be adjusted to load libyajl from the same location
-python macdeployqtfix.py "${app}/Contents/MacOS/yajl.so" "/usr/local/opt/qt/bin"
+if [ "${USE_CJSON}" != "Y" ] ; then
+  cp "${HOME}/.luarocks/lib/lua/5.1/yajl.so" "${app}/Contents/MacOS"
+  # yajl has to be adjusted to load libyajl from the same location
+  python macdeployqtfix.py "${app}/Contents/MacOS/yajl.so" "/usr/local/opt/qt/bin"
+fi
 
 # Edit some nice plist entries, don't fail if entries already exist
 if [ -z "${ptb}" ]; then


### PR DESCRIPTION
This looks like it might be a workable way of temporarily(?) switching between yajl and cjson.