### PR TITLE
allow newer glibc version, enable creating AppImage files using Ubuntu 20.04

### DIFF
--- a/generic-linux/make-installer.sh
+++ b/generic-linux/make-installer.sh
@@ -116,8 +116,12 @@ if [ -z "$(ls build/lib/libssl.so*)" ]; then
   exit 1
 fi
 
+#NOTE: the -unsupported-allow-new-glibc should be removed again around May 31 2023
+# It is here temporarily to allow Github Actions to make test builds during a gap between
+# between when Github Actions drops support for 18.04 prior to when Ubuntu itself does
 echo "Generating AppImage"
 ./squashfs-root/AppRun ./build/mudlet -appimage \
+  -unsupported-allow-new-glibc \
   -executable=build/lib/rex_pcre.so -executable=build/lib/zip.so \
   -executable=build/lib/luasql/sqlite3.so -executable=build/lib/yajl.so \
   -executable=build/lib/libssl.so.1.1 \


### PR DESCRIPTION
Adding this line should allow a more recent version of Ubuntu to build an AppImage even though it is not the oldest supported version of Ubuntu.

Github Actions runners are dropping support for Ubuntu 18.04 by [April 1 2023](https://github.com/actions/runner-images/issues/6002).
Ubuntu itself is ending support for 18.04 on [May 31 2023](https://ubuntu.com/blog/18-04-end-of-standard-support).
The builder wants to run on the oldest Ubuntu for as long as it is supported, meaning 2 month gap of either no AppImage or using our own systems instead of Github.

There is a check in linuxdeployqt [comparing glibc version against 2.28](https://github.com/probonopd/linuxdeployqt/blob/deebf70ea60b7fd19321e7a0eb884d6d986f7b5c/tools/linuxdeployqt/main.cpp#L193-L212) but there is an argument available to [skip that check](https://github.com/probonopd/linuxdeployqt/blob/deebf70ea60b7fd19321e7a0eb884d6d986f7b5c/tools/linuxdeployqt/main.cpp#L158-L160) to allow it to run on more recent, at the expense of building one incompatible with 18.04.

End of support for 16.04 was April 29 2021 by Ubuntu, and the linuxdeployqt bumped on [April 26](https://github.com/probonopd/linuxdeployqt/commit/a3648aed4ad98bf91d087135a92d08806e52e291).  So this line can be removed again probably May 31 2023 or possibly some days earlier based on last time, just look over on that project and verify.