### PR TITLE
Revert "Update make-installer.sh (#106)"

### DIFF
--- a/generic-linux/make-installer.sh
+++ b/generic-linux/make-installer.sh
@@ -116,12 +116,8 @@ if [ -z "$(ls build/lib/libssl.so*)" ]; then
   exit 1
 fi
 
-#NOTE: the -unsupported-allow-new-glibc should be removed again around May 31 2023
-# It is here temporarily to allow Github Actions to make test builds during a gap between
-# between when Github Actions drops support for 18.04 prior to when Ubuntu itself does
 echo "Generating AppImage"
 ./squashfs-root/AppRun ./build/mudlet -appimage \
-  -unsupported-allow-new-glibc \
   -executable=build/lib/rex_pcre.so -executable=build/lib/zip.so \
   -executable=build/lib/luasql/sqlite3.so -executable=build/lib/yajl.so \
   -executable=build/lib/libssl.so.1.1 \


### PR DESCRIPTION
This reverts commit e96ff96a1d96fc183a63758cfb48dfedd3208e4a.

The linuxdeployqt changed the version they look for on April 1 shortly after we adjusted for it. 
 https://github.com/probonopd/linuxdeployqt/commit/559097432235a8be5508371e3b7114132ab33b95