### PR TITLE
Infrastructure: fix MacOS libzstd.1.dylib crashes

### DIFF
--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -145,11 +145,12 @@ python macdeployqtfix.py "${app}/Contents/MacOS/brimworks/zip.so" "/usr/local"
 
 # Also fix up latest libzip which has a dependency on libzstd (and liblzma) and
 # copy them into "${app}/Contents/Frameworks":
-cp "/usr/local/Cellar/libzip/1.10.1/lib/libzip.5.dylib" "${app}/Contents/Frameworks"
-# Fix up the loader to get the next two libraries from within our bundle,
-# the ../../../../opt/ directorys are ones containing links to the actual
-# library files that are in the homebrew /usr/local/Celler/ and that does not
-# help us on a different machine that doesn't have them:
+cp "/usr/local/Cellar/libzip/1.10.1/lib/libzip.5.5.dylib" "${app}/Contents/Frameworks/libzip.5.dylib"
+# Fix up the loader to get the next two libraries as dependencies of the above
+# from within our bundle, the ../../../../opt/ directorys are ones containing
+# symbolic links to the actual library files that are in the homebrew
+# /usr/local/Celler/ and that does not help end-users on a different machine
+# that doesn't have them:
 install_name_tool -change @loader_path/../../../../opt/xz/lib/liblzma.5.dylib @executable_path/../Frameworks/liblzma.5.dylib ./libzip.5.dylib
 install_name_tool -change @loader_path/../../../../opt/zstd/lib/libzstd.1.dylib  @executable_path/../Frameworks/libzstd.1.dylib ./libzip.5.dylib
 

--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -143,10 +143,20 @@ if [ -n "$GITHUB_REPOSITORY" ] ; then
 fi
 python macdeployqtfix.py "${app}/Contents/MacOS/brimworks/zip.so" "/usr/local"
 
-# Also fix up latest libzip which has a dependency on libzstd - copy them both
-# into "${app}/Contents/Frameworks":
-cp "/usr/local/lib/libzip.5.dylib" "${app}/Contents/Frameworks"
-cp "/usr/local/lib/libzstd.1.dylib" "${app}/Contents/Frameworks"
+# Also fix up latest libzip which has a dependency on libzstd (and liblzma) and
+# copy them into "${app}/Contents/Frameworks":
+cp "/usr/local/Cellar/libzip/1.10.1/lib/libzip.5.dylib" "${app}/Contents/Frameworks"
+# Fix up the loader to get the next two libraries from within our bundle,
+# the ../../../../opt/ directorys are ones containing links to the actual
+# library files that are in the homebrew /usr/local/Celler/ and that does not
+# help us on a different machine that doesn't have them:
+install_name_tool -change @loader_path/../../../../opt/xz/lib/liblzma.5.dylib @executable_path/../Frameworks/liblzma.5.dylib ./libzip.5.dylib
+install_name_tool -change @loader_path/../../../../opt/zstd/lib/libzstd.1.dylib  @executable_path/../Frameworks/libzstd.1.dylib ./libzip.5.dylib
+
+cp "/usr/local/Cellar/xz/5.4.4/lib/liblzma.5.dylib" "${app}/Contents/Frameworks"
+
+# Rename this one to match the name that libzip is looking for:
+cp "/usr/local/Cellar/zstd/1.5.5/lib/libzstd.1.5.5.dylib" "${app}/Contents/Frameworks/libzstd.1.dylib"
 
 cp "${SOURCE_DIR}/3rdparty/discord/rpc/lib/libdiscord-rpc.dylib" "${app}/Contents/Frameworks"
 

--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -151,8 +151,8 @@ cp "/usr/local/Cellar/libzip/1.10.1/lib/libzip.5.5.dylib" "${app}/Contents/Frame
 # symbolic links to the actual library files that are in the homebrew
 # /usr/local/Celler/ and that does not help end-users on a different machine
 # that doesn't have them:
-install_name_tool -change @loader_path/../../../../opt/xz/lib/liblzma.5.dylib @executable_path/../Frameworks/liblzma.5.dylib ./libzip.5.dylib
-install_name_tool -change @loader_path/../../../../opt/zstd/lib/libzstd.1.dylib  @executable_path/../Frameworks/libzstd.1.dylib ./libzip.5.dylib
+install_name_tool -change @loader_path/../../../../opt/xz/lib/liblzma.5.dylib @executable_path/../Frameworks/liblzma.5.dylib ${app}/Contents/Frameworks/libzip.5.dylib
+install_name_tool -change @loader_path/../../../../opt/zstd/lib/libzstd.1.dylib  @executable_path/../Frameworks/libzstd.1.dylib ${app}/Contents/Frameworks/libzip.5.dylib
 
 cp "/usr/local/Cellar/xz/5.4.4/lib/liblzma.5.dylib" "${app}/Contents/Frameworks"
 

--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -143,21 +143,21 @@ if [ -n "$GITHUB_REPOSITORY" ] ; then
 fi
 python macdeployqtfix.py "${app}/Contents/MacOS/brimworks/zip.so" "/usr/local"
 
-# Also fix up latest libzip which has a dependency on libzstd (and liblzma) and
-# copy them into "${app}/Contents/Frameworks":
+# Also fix up a separate (does it have to be?) copy of libzip which has a
+# dependency on libzstd (and liblzma) and copy them into
+# "${app}/Contents/Frameworks" - which is a sort of standard placement in App
+# bundles:
 cp "/usr/local/Cellar/libzip/1.10.1/lib/libzip.5.5.dylib" "${app}/Contents/Frameworks/libzip.5.dylib"
-# Fix up the loader to get the next two libraries as dependencies of the above
-# from within our bundle, the ../../../../opt/ directorys are ones containing
-# symbolic links to the actual library files that are in the homebrew
-# /usr/local/Celler/ and that does not help end-users on a different machine
-# that doesn't have them:
-install_name_tool -change @loader_path/../../../../opt/xz/lib/liblzma.5.dylib @executable_path/../Frameworks/liblzma.5.dylib ${app}/Contents/Frameworks/libzip.5.dylib
-install_name_tool -change @loader_path/../../../../opt/zstd/lib/libzstd.1.dylib  @executable_path/../Frameworks/libzstd.1.dylib ${app}/Contents/Frameworks/libzip.5.dylib
-
 cp "/usr/local/Cellar/xz/5.4.4/lib/liblzma.5.dylib" "${app}/Contents/Frameworks"
-
 # Rename this one to match the name that libzip is looking for:
 cp "/usr/local/Cellar/zstd/1.5.5/lib/libzstd.1.5.5.dylib" "${app}/Contents/Frameworks/libzstd.1.dylib"
+
+# Fix up the loader to get the other two (depencdency) libraries from within our
+# bundle, the ../../../../opt/ directorys are ones containing symbolic links to
+# the actual library files that are in the homebrew /usr/local/Celler/ and that
+# does not help end-users on a different machine that doesn't have them:
+install_name_tool -change @loader_path/../../../../opt/xz/lib/liblzma.5.dylib @executable_path/../Frameworks/liblzma.5.dylib ${app}/Contents/Frameworks/libzip.5.dylib
+install_name_tool -change @loader_path/../../../../opt/zstd/lib/libzstd.1.dylib  @executable_path/../Frameworks/libzstd.1.dylib ${app}/Contents/Frameworks/libzip.5.dylib
 
 cp "${SOURCE_DIR}/3rdparty/discord/rpc/lib/libdiscord-rpc.dylib" "${app}/Contents/Frameworks"
 

--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -143,6 +143,11 @@ if [ -n "$GITHUB_REPOSITORY" ] ; then
 fi
 python macdeployqtfix.py "${app}/Contents/MacOS/brimworks/zip.so" "/usr/local"
 
+# Also fix up latest libzip which has a dependency on libzstd - copy them both
+# into "${app}/Contents/Frameworks":
+cp "/usr/local/lib/libzip.5.dylib" "${app}/Contents/Frameworks"
+cp "/usr/local/lib/libzstd.1.dylib" "${app}/Contents/Frameworks"
+
 cp "${SOURCE_DIR}/3rdparty/discord/rpc/lib/libdiscord-rpc.dylib" "${app}/Contents/Frameworks"
 
 if [ -d "${SOURCE_DIR}/3rdparty/lua_code_formatter" ]; then


### PR DESCRIPTION
Copy both `libzip.5.dylib` and `libzstd.1.dylib` into a location where they seem to be needed/expected. For some reason the existing tooling does not deal with these files. This PR is temporarily being used by https://github.com/Mudlet/Mudlet/pull/6998.