### PR TITLE
Infrastructure: update liblzma version in MacOS builds

### DIFF
--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -146,11 +146,13 @@ python macdeployqtfix.py "${app}/Contents/MacOS/brimworks/zip.so" "/usr/local"
 # Also fix up a separate (does it have to be?) copy of libzip which has a
 # dependency on libzstd (and liblzma) and copy them into
 # "${app}/Contents/Frameworks" - which is a sort of standard placement in App
-# bundles:
-cp "/usr/local/Cellar/libzip/1.10.1/lib/libzip.5.5.dylib" "${app}/Contents/Frameworks/libzip.5.dylib"
-cp "/usr/local/Cellar/xz/5.4.5/lib/liblzma.5.dylib" "${app}/Contents/Frameworks"
-# Rename this one to match the name that libzip is looking for:
-cp "/usr/local/Cellar/zstd/1.5.5/lib/libzstd.1.5.5.dylib" "${app}/Contents/Frameworks/libzstd.1.dylib"
+# bundles - to enable things to keep working when minor or patch version numbers
+# change it is necessary to use some wildcards, these may actually target a
+# symbolic link but when they are copied the linked to file will be what is
+# copied:
+cp "/usr/local/Cellar/libzip/1.*/lib/libzip.5.dylib" "${app}/Contents/Frameworks/libzip.5.dylib"
+cp "/usr/local/Cellar/xz/5.*/lib/liblzma.5.dylib" "${app}/Contents/Frameworks/liblzma.5.dylib"
+cp "/usr/local/Cellar/zstd/1.*/lib/libzstd.1.dylib" "${app}/Contents/Frameworks/libzstd.1.dylib"
 
 # Fix up the loader to get the other two (depencdency) libraries from within our
 # bundle, the ../../../../opt/ directorys are ones containing symbolic links to

--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -148,7 +148,7 @@ python macdeployqtfix.py "${app}/Contents/MacOS/brimworks/zip.so" "/usr/local"
 # "${app}/Contents/Frameworks" - which is a sort of standard placement in App
 # bundles:
 cp "/usr/local/Cellar/libzip/1.10.1/lib/libzip.5.5.dylib" "${app}/Contents/Frameworks/libzip.5.dylib"
-cp "/usr/local/Cellar/xz/5.4.4/lib/liblzma.5.dylib" "${app}/Contents/Frameworks"
+cp "/usr/local/Cellar/xz/5.4.5/lib/liblzma.5.dylib" "${app}/Contents/Frameworks"
 # Rename this one to match the name that libzip is looking for:
 cp "/usr/local/Cellar/zstd/1.5.5/lib/libzstd.1.5.5.dylib" "${app}/Contents/Frameworks/libzstd.1.dylib"
 

--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -150,14 +150,12 @@ python macdeployqtfix.py "${app}/Contents/MacOS/brimworks/zip.so" "/usr/local"
 # change it is necessary to use some wildcards, these may actually target a
 # symbolic link but when they are copied the linked to file will be what is
 # copied:
-# Copy the right file explicity so we can examine why the wildcard one doesn't work
-ls -l /usr/local/Cellar/libzip/1.*/lib/libzip.5.*.dylib
-cp "/usr/local/Cellar/libzip/1.10.1/lib/libzip.5.5.dylib" "${app}/Contents/Frameworks/libzip.5.dylib"
-# cp "/usr/local/Cellar/libzip/1.*/lib/libzip.5.*.dylib" "${app}/Contents/Frameworks/libzip.5.dylib"
-ls -l /usr/local/Cellar/xz/5.*/lib/liblzma.5.dylib
-cp "/usr/local/Cellar/xz/5.*/lib/liblzma.5.dylib" "${app}/Contents/Frameworks/liblzma.5.dylib"
-ls -l /usr/local/Cellar/zstd/1.*/lib/libzstd.1.dylib
-cp "/usr/local/Cellar/zstd/1.*/lib/libzstd.1.dylib" "${app}/Contents/Frameworks/libzstd.1.dylib"
+ls -l /usr/local/Cellar/libzip/1.1?.?/lib/libzip.5.?.dylib
+cp /usr/local/Cellar/libzip/1.1?.?/lib/libzip.5.?.dylib "${app}/Contents/Frameworks/libzip.5.dylib"
+ls -l /usr/local/Cellar/xz/5.?/lib/liblzma.5.dylib
+cp /usr/local/Cellar/xz/5.?/lib/liblzma.5.dylib "${app}/Contents/Frameworks/liblzma.5.dylib"
+ls -l /usr/local/Cellar/zstd/1.?/lib/libzstd.1.dylib
+cp /usr/local/Cellar/zstd/1.?/lib/libzstd.1.dylib" "${app}/Contents/Frameworks/libzstd.1.dylib"
 
 # Fix up the loader to get the other two (depencdency) libraries from within our
 # bundle, the ../../../../opt/ directorys are ones containing symbolic links to

--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -150,8 +150,11 @@ python macdeployqtfix.py "${app}/Contents/MacOS/brimworks/zip.so" "/usr/local"
 # change it is necessary to use some wildcards, these may actually target a
 # symbolic link but when they are copied the linked to file will be what is
 # copied:
+ls -l /usr/local/Cellar/libzip/1.*/lib/libzip.5.*.dylib
 cp "/usr/local/Cellar/libzip/1.*/lib/libzip.5.*.dylib" "${app}/Contents/Frameworks/libzip.5.dylib"
+ls -l /usr/local/Cellar/xz/5.*/lib/liblzma.5.dylib
 cp "/usr/local/Cellar/xz/5.*/lib/liblzma.5.dylib" "${app}/Contents/Frameworks/liblzma.5.dylib"
+ls -l /usr/local/Cellar/zstd/1.*/lib/libzstd.1.dylib
 cp "/usr/local/Cellar/zstd/1.*/lib/libzstd.1.dylib" "${app}/Contents/Frameworks/libzstd.1.dylib"
 
 # Fix up the loader to get the other two (depencdency) libraries from within our

--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -150,6 +150,8 @@ python macdeployqtfix.py "${app}/Contents/MacOS/brimworks/zip.so" "/usr/local"
 # change it is necessary to use some wildcards, these may actually target a
 # symbolic link but when they are copied the linked to file will be what is
 # copied:
+# Copy the right file explicity so we can examine why the wildcard one doesn't work
+cp "/usr/local/Cellar/libzip/1.10.1/lib/libzip.5.5.dylib" "${app}/Contents/Frameworks/libzip.5.dylib"
 ls -l /usr/local/Cellar/libzip/1.*/lib/libzip.5.*.dylib
 cp "/usr/local/Cellar/libzip/1.*/lib/libzip.5.*.dylib" "${app}/Contents/Frameworks/libzip.5.dylib"
 ls -l /usr/local/Cellar/xz/5.*/lib/liblzma.5.dylib

--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -150,12 +150,9 @@ python macdeployqtfix.py "${app}/Contents/MacOS/brimworks/zip.so" "/usr/local"
 # change it is necessary to use some wildcards, these may actually target a
 # symbolic link but when they are copied the linked to file will be what is
 # copied:
-ls -l /usr/local/Cellar/libzip/1.1?.?/lib/libzip.5.?.dylib
-cp /usr/local/Cellar/libzip/1.1?.?/lib/libzip.5.?.dylib "${app}/Contents/Frameworks/libzip.5.dylib"
-ls -l /usr/local/Cellar/xz/5.?/lib/liblzma.5.dylib
-cp /usr/local/Cellar/xz/5.?/lib/liblzma.5.dylib "${app}/Contents/Frameworks/liblzma.5.dylib"
-ls -l /usr/local/Cellar/zstd/1.?/lib/libzstd.1.dylib
-cp /usr/local/Cellar/zstd/1.?/lib/libzstd.1.dylib" "${app}/Contents/Frameworks/libzstd.1.dylib"
+cp -v /usr/local/Cellar/libzip/1.1?.?/lib/libzip.5.?.dylib "${app}/Contents/Frameworks/libzip.5.dylib"
+cp -v /usr/local/Cellar/xz/5.?.?/lib/liblzma.5.dylib "${app}/Contents/Frameworks/liblzma.5.dylib"
+cp -v /usr/local/Cellar/zstd/1.?.?/lib/libzstd.1.dylib" "${app}/Contents/Frameworks/libzstd.1.dylib"
 
 # Fix up the loader to get the other two (depencdency) libraries from within our
 # bundle, the ../../../../opt/ directorys are ones containing symbolic links to

--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -151,9 +151,9 @@ python macdeployqtfix.py "${app}/Contents/MacOS/brimworks/zip.so" "/usr/local"
 # symbolic link but when they are copied the linked to file will be what is
 # copied:
 # Copy the right file explicity so we can examine why the wildcard one doesn't work
-cp "/usr/local/Cellar/libzip/1.10.1/lib/libzip.5.5.dylib" "${app}/Contents/Frameworks/libzip.5.dylib"
 ls -l /usr/local/Cellar/libzip/1.*/lib/libzip.5.*.dylib
-cp "/usr/local/Cellar/libzip/1.*/lib/libzip.5.*.dylib" "${app}/Contents/Frameworks/libzip.5.dylib"
+cp "/usr/local/Cellar/libzip/1.10.1/lib/libzip.5.5.dylib" "${app}/Contents/Frameworks/libzip.5.dylib"
+# cp "/usr/local/Cellar/libzip/1.*/lib/libzip.5.*.dylib" "${app}/Contents/Frameworks/libzip.5.dylib"
 ls -l /usr/local/Cellar/xz/5.*/lib/liblzma.5.dylib
 cp "/usr/local/Cellar/xz/5.*/lib/liblzma.5.dylib" "${app}/Contents/Frameworks/liblzma.5.dylib"
 ls -l /usr/local/Cellar/zstd/1.*/lib/libzstd.1.dylib

--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -152,7 +152,7 @@ python macdeployqtfix.py "${app}/Contents/MacOS/brimworks/zip.so" "/usr/local"
 # copied:
 cp -v /usr/local/Cellar/libzip/1.1?.?/lib/libzip.5.?.dylib "${app}/Contents/Frameworks/libzip.5.dylib"
 cp -v /usr/local/Cellar/xz/5.?.?/lib/liblzma.5.dylib "${app}/Contents/Frameworks/liblzma.5.dylib"
-cp -v /usr/local/Cellar/zstd/1.?.?/lib/libzstd.1.dylib" "${app}/Contents/Frameworks/libzstd.1.dylib"
+cp -v /usr/local/Cellar/zstd/1.?.?/lib/libzstd.1.dylib "${app}/Contents/Frameworks/libzstd.1.dylib"
 
 # Fix up the loader to get the other two (depencdency) libraries from within our
 # bundle, the ../../../../opt/ directorys are ones containing symbolic links to

--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -150,7 +150,7 @@ python macdeployqtfix.py "${app}/Contents/MacOS/brimworks/zip.so" "/usr/local"
 # change it is necessary to use some wildcards, these may actually target a
 # symbolic link but when they are copied the linked to file will be what is
 # copied:
-cp "/usr/local/Cellar/libzip/1.*/lib/libzip.5.dylib" "${app}/Contents/Frameworks/libzip.5.dylib"
+cp "/usr/local/Cellar/libzip/1.*/lib/libzip.5.*.dylib" "${app}/Contents/Frameworks/libzip.5.dylib"
 cp "/usr/local/Cellar/xz/5.*/lib/liblzma.5.dylib" "${app}/Contents/Frameworks/liblzma.5.dylib"
 cp "/usr/local/Cellar/zstd/1.*/lib/libzstd.1.dylib" "${app}/Contents/Frameworks/libzstd.1.dylib"
 


### PR DESCRIPTION
This updates a script so the main repository code can run to completion - but will need further revision to make it less sensitive to even a patch level version change.