### PR TITLE
Update rex_pcre to rex_pcre2 for PCRE2 library

### DIFF
--- a/generic-linux/make-installer.sh
+++ b/generic-linux/make-installer.sh
@@ -78,7 +78,7 @@ mkdir -p build/lib/brimworks
 
 cp "$SOURCE_DIR"/3rdparty/discord/rpc/lib/libdiscord-rpc.so build/lib/
 
-for lib in lfs rex_pcre luasql/sqlite3 brimworks/zip lua-utf8 yajl
+for lib in lfs rex_pcre2 luasql/sqlite3 brimworks/zip lua-utf8 yajl
 do
   found=0
   for path in $(luarocks path --lr-cpath | tr ";" "\n")
@@ -118,7 +118,7 @@ fi
 
 echo "Generating AppImage"
 ./squashfs-root/AppRun ./build/mudlet -appimage \
-  -executable=build/lib/rex_pcre.so -executable=build/lib/zip.so \
+  -executable=build/lib/rex_pcre2.so -executable=build/lib/zip.so \
   -executable=build/lib/luasql/sqlite3.so -executable=build/lib/yajl.so \
   -executable=build/lib/libssl.so.1.1 \
   -executable=build/lib/libssl.so.1.0.0 \

--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -111,11 +111,11 @@ python macdeployqtfix.py "${app}/Contents/MacOS/Mudlet" "${QT_DIR}" $( [ -n "$DE
 # These will be manually fixed up because macdeployqtfix is not really designed to handle individual libraries.
 echo "Bundling dynamic libraries"
 cp -v "${HOME}/.luarocks/lib/lua/5.1/lfs.so" "${app}/Contents/MacOS"
-cp -v "${HOME}/.luarocks/lib/lua/5.1/rex_pcre.so" "${app}/Contents/MacOS"
-# rex_pcre has to be adjusted to load libpcre from the same location
-cp -v "${HOMEBREW_PREFIX}/opt/pcre/lib/libpcre.1.dylib" "${app}/Contents/Frameworks/libpcre.1.dylib"
-install_name_tool -id "@executable_path/../Frameworks/libpcre.1.dylib" "${app}/Contents/Frameworks/libpcre.1.dylib"
-install_name_tool -change "${HOMEBREW_PREFIX}/opt/pcre/lib/libpcre.1.dylib" "@executable_path/../Frameworks/libpcre.1.dylib" "${app}/Contents/MacOS/rex_pcre.so"
+cp -v "${HOME}/.luarocks/lib/lua/5.1/rex_pcre2.so" "${app}/Contents/MacOS"
+# rex_pcre2 has to be adjusted to load libpcre2 from the same location
+cp -v "${HOMEBREW_PREFIX}/opt/pcre2/lib/libpcre2-8.0.dylib" "${app}/Contents/Frameworks/libpcre2-8.0.dylib"
+install_name_tool -id "@executable_path/../Frameworks/libpcre2-8.0.dylib" "${app}/Contents/Frameworks/libpcre2-8.0.dylib"
+install_name_tool -change "${HOMEBREW_PREFIX}/opt/pcre2/lib/libpcre2-8.0.dylib" "@executable_path/../Frameworks/libpcre2-8.0.dylib" "${app}/Contents/MacOS/rex_pcre2.so"
 
 cp -r "${HOME}/.luarocks/lib/lua/5.1/luasql" "${app}/Contents/MacOS"
 cp -v ${HOMEBREW_PREFIX}/opt/sqlite/lib/libsqlite3.0.dylib  "${app}/Contents/Frameworks/"


### PR DESCRIPTION
## Summary
- Update macOS bundling script to use rex_pcre2.so instead of rex_pcre.so
- Update macOS bundling to use libpcre2-8.0.dylib instead of libpcre.1.dylib
- Update Linux bundling script to use rex_pcre2.so instead of rex_pcre.so

## Context
This change aligns with the PCRE to PCRE2 migration in the main Mudlet repository (PR #8533). The CI was failing because it was trying to copy rex_pcre.so which no longer exists after the migration to lrexlib-pcre2.

## Test plan
- [x] Verify CI builds complete successfully for macOS
- [x] Verify CI builds complete successfully for Linux
- [x] Confirm bundled libraries are correctly linked