### PR TITLE
Add: Sentry crash handler and MudletCrashReporter to the distributed package on Linux and MacOS

### DIFF
--- a/generic-linux/make-installer.sh
+++ b/generic-linux/make-installer.sh
@@ -55,6 +55,18 @@ rm -f Mudlet*.AppImage
 # move the binary up to the build folder (they differ between qmake and cmake,
 # so we use find to find the binary
 find "$BUILD_DIR"/ -iname mudlet -type f -exec cp '{}' build/ \;
+
+if [ "$WITH_SENTRY" = "ON" ]; then
+  for f in mudletcrashreporter crashpad_handler; do
+    found_file=$(find "$BUILD_DIR"/ -iname "$f" -type f)
+    if [ -z "$found_file" ]; then
+      echo "Error: $f not found in $BUILD_DIR"
+      exit 1
+    fi
+    cp "$found_file" build/
+  done
+fi
+
 # get mudlet-lua in there as well so linuxdeployqt bundles it
 cp -rf "$SOURCE_DIR"/src/mudlet-lua build/
 # copy Lua translations

--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -112,10 +112,24 @@ python macdeployqtfix.py "${app}/Contents/MacOS/Mudlet" "${QT_DIR}" $( [ -n "$DE
 echo "Bundling dynamic libraries"
 cp -v "${HOME}/.luarocks/lib/lua/5.1/lfs.so" "${app}/Contents/MacOS"
 cp -v "${HOME}/.luarocks/lib/lua/5.1/rex_pcre2.so" "${app}/Contents/MacOS"
-# rex_pcre2 has to be adjusted to load libpcre2 from the same location
-cp -v "${HOMEBREW_PREFIX}/opt/pcre2/lib/libpcre2-8.0.dylib" "${app}/Contents/Frameworks/libpcre2-8.0.dylib"
-install_name_tool -id "@executable_path/../Frameworks/libpcre2-8.0.dylib" "${app}/Contents/Frameworks/libpcre2-8.0.dylib"
-install_name_tool -change "${HOMEBREW_PREFIX}/opt/pcre2/lib/libpcre2-8.0.dylib" "@executable_path/../Frameworks/libpcre2-8.0.dylib" "${app}/Contents/MacOS/rex_pcre2.so"
+
+# ======= Bundle Sentry executables =======
+if [ "$WITH_SENTRY" = "ON" ]; then
+    for f in MudletCrashReporter crashpad_handler; do
+        found_file=$(find "$BUILD_DIR"/ -iname "$f" -type f)
+        if [ -z "$found_file" ]; then
+            echo "Error: $f not found in $BUILD_DIR"
+            exit 1
+        fi
+        cp "$found_file" "${app}/Contents/MacOS/"
+        chmod +x "${app}/Contents/MacOS/$f"
+    done
+fi
+
+# rex_pcre has to be adjusted to load libpcre from the same location
+cp -v "${HOMEBREW_PREFIX}/opt/pcre/lib/libpcre.1.dylib" "${app}/Contents/Frameworks/libpcre.1.dylib"
+install_name_tool -id "@executable_path/../Frameworks/libpcre.1.dylib" "${app}/Contents/Frameworks/libpcre.1.dylib"
+install_name_tool -change "${HOMEBREW_PREFIX}/opt/pcre/lib/libpcre.1.dylib" "@executable_path/../Frameworks/libpcre.1.dylib" "${app}/Contents/MacOS/rex_pcre.so"
 
 cp -r "${HOME}/.luarocks/lib/lua/5.1/luasql" "${app}/Contents/MacOS"
 cp -v ${HOMEBREW_PREFIX}/opt/sqlite/lib/libsqlite3.0.dylib  "${app}/Contents/Frameworks/"

--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -112,6 +112,10 @@ python macdeployqtfix.py "${app}/Contents/MacOS/Mudlet" "${QT_DIR}" $( [ -n "$DE
 echo "Bundling dynamic libraries"
 cp -v "${HOME}/.luarocks/lib/lua/5.1/lfs.so" "${app}/Contents/MacOS"
 cp -v "${HOME}/.luarocks/lib/lua/5.1/rex_pcre2.so" "${app}/Contents/MacOS"
+# rex_pcre2 has to be adjusted to load libpcre2 from the same location
+cp -v "${HOMEBREW_PREFIX}/opt/pcre2/lib/libpcre2-8.0.dylib" "${app}/Contents/Frameworks/libpcre2-8.0.dylib"
+install_name_tool -id "@executable_path/../Frameworks/libpcre2-8.0.dylib" "${app}/Contents/Frameworks/libpcre2-8.0.dylib"
+install_name_tool -change "${HOMEBREW_PREFIX}/opt/pcre2/lib/libpcre2-8.0.dylib" "@executable_path/../Frameworks/libpcre2-8.0.dylib" "${app}/Contents/MacOS/rex_pcre2.so"
 
 # ======= Bundle Sentry executables =======
 if [ "$WITH_SENTRY" = "ON" ]; then
@@ -125,11 +129,6 @@ if [ "$WITH_SENTRY" = "ON" ]; then
         chmod +x "${app}/Contents/MacOS/$f"
     done
 fi
-
-# rex_pcre has to be adjusted to load libpcre from the same location
-cp -v "${HOMEBREW_PREFIX}/opt/pcre/lib/libpcre.1.dylib" "${app}/Contents/Frameworks/libpcre.1.dylib"
-install_name_tool -id "@executable_path/../Frameworks/libpcre.1.dylib" "${app}/Contents/Frameworks/libpcre.1.dylib"
-install_name_tool -change "${HOMEBREW_PREFIX}/opt/pcre/lib/libpcre.1.dylib" "@executable_path/../Frameworks/libpcre.1.dylib" "${app}/Contents/MacOS/rex_pcre.so"
 
 cp -r "${HOME}/.luarocks/lib/lua/5.1/luasql" "${app}/Contents/MacOS"
 cp -v ${HOMEBREW_PREFIX}/opt/sqlite/lib/libsqlite3.0.dylib  "${app}/Contents/Frameworks/"


### PR DESCRIPTION
Related to https://github.com/Mudlet/Mudlet/pull/8540

**Add the two Sentry executables to the bundle**

This PR includes the Sentry crash reporter executables (MudletCrashReporter and crashpad_handler) in the builds for Linux and macOS.

I’ve already added the Sentry executables to the Windows package (in CI/package-mudlet-for-windows.sh).