### PR TITLE
Fix Sentry executables wrongly copied into the bundle

### DIFF
--- a/generic-linux/make-installer.sh
+++ b/generic-linux/make-installer.sh
@@ -63,7 +63,7 @@ if [ "$WITH_SENTRY" = "ON" ]; then
       echo "Error: $f not found in $BUILD_DIR"
       exit 1
     fi
-    cp "$found_file" build/
+    cp -f "$found_file" build/
   done
 fi
 

--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -125,7 +125,7 @@ if [ "$WITH_SENTRY" = "ON" ]; then
             echo "Error: $f not found in $BUILD_DIR"
             exit 1
         fi
-        cp "$found_file" "${app}/Contents/MacOS/"
+        cp -f "$found_file" "${app}/Contents/MacOS/"
         chmod +x "${app}/Contents/MacOS/$f"
     done
 fi


### PR DESCRIPTION
This PR ensures that the Sentry executables (MudletCrashReporter and crashpad_handler) are copied with cp -f into the macOS bundle.

Motivation for adding:
Fix the CI failing