### PR TITLE
Fix: Sentry Executables are copied twice on macOS

### DIFF
--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -117,19 +117,6 @@ cp -v "${HOMEBREW_PREFIX}/opt/pcre2/lib/libpcre2-8.0.dylib" "${app}/Contents/Fra
 install_name_tool -id "@executable_path/../Frameworks/libpcre2-8.0.dylib" "${app}/Contents/Frameworks/libpcre2-8.0.dylib"
 install_name_tool -change "${HOMEBREW_PREFIX}/opt/pcre2/lib/libpcre2-8.0.dylib" "@executable_path/../Frameworks/libpcre2-8.0.dylib" "${app}/Contents/MacOS/rex_pcre2.so"
 
-# ======= Bundle Sentry executables =======
-if [ "$WITH_SENTRY" = "ON" ]; then
-    for f in MudletCrashReporter crashpad_handler; do
-        found_file=$(find "$BUILD_DIR"/ -iname "$f" -type f)
-        if [ -z "$found_file" ]; then
-            echo "Error: $f not found in $BUILD_DIR"
-            exit 1
-        fi
-        cp -f "$found_file" "${app}/Contents/MacOS/"
-        chmod +x "${app}/Contents/MacOS/$f"
-    done
-fi
-
 cp -r "${HOME}/.luarocks/lib/lua/5.1/luasql" "${app}/Contents/MacOS"
 cp -v ${HOMEBREW_PREFIX}/opt/sqlite/lib/libsqlite3.0.dylib  "${app}/Contents/Frameworks/"
 install_name_tool -id  "@executable_path/../Frameworks/libsqlite3.0.dylib" "${app}/Contents/Frameworks/libsqlite3.0.dylib" 


### PR DESCRIPTION
This PR removes the code that copies MudletCrashReporter and crashpad_handler into the macOS bundle.

According to the failing CI logs, these executables **are already included in the package**, and the copy step was causing the workflow to fail with:

cp: source and destination are identical (not copied)

**Motivation for adding this to Mudlet:**
CI failures.