### PR TITLE
Fix: explicitly copy Sentry executables into the Linux AppImage

### DIFF
--- a/generic-linux/make-installer.sh
+++ b/generic-linux/make-installer.sh
@@ -57,14 +57,8 @@ rm -f Mudlet*.AppImage
 find "$BUILD_DIR"/ -iname mudlet -type f -exec cp '{}' build/ \;
 
 if [ "$WITH_SENTRY" = "ON" ]; then
-  for f in mudletcrashreporter crashpad_handler; do
-    found_file=$(find "$BUILD_DIR"/ -iname "$f" -type f)
-    if [ -z "$found_file" ]; then
-      echo "Error: $f not found in $BUILD_DIR"
-      exit 1
-    fi
-    cp -f "$found_file" build/
-  done
+  cp -v "$BUILD_DIR/src/mudletcrashreporter" build/
+  cp -v "$BUILD_DIR/src/crashpad_handler" build/
 fi
 
 # get mudlet-lua in there as well so linuxdeployqt bundles it

--- a/generic-linux/make-installer.sh
+++ b/generic-linux/make-installer.sh
@@ -57,7 +57,7 @@ rm -f Mudlet*.AppImage
 find "$BUILD_DIR"/ -iname mudlet -type f -exec cp '{}' build/ \;
 
 if [ "$WITH_SENTRY" = "ON" ]; then
-  cp -v "$BUILD_DIR/src/mudletcrashreporter" build/
+  cp -v "$BUILD_DIR/src/MudletCrashReporter" build/
   cp -v "$BUILD_DIR/src/crashpad_handler" build/
 fi
 


### PR DESCRIPTION
This PR removes the find logic and explicitly references the paths of the Sentry executables (mudletcrashreporter and crashpad_handler) so they can be reliably copied into the Linux .AppImage.