### PR TITLE
Infrastructure: revise displayed Copyright year to 2026

### DIFF
--- a/windows/mudlet.nuspec
+++ b/windows/mudlet.nuspec
@@ -11,7 +11,7 @@
     <iconUrl>https://raw.githubusercontent.com/Mudlet/Mudlet/development/src/icons/mudlet_main_512x512_6XS_icon.ico</iconUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>A cross-platform, open source, and super fast MUD client with scripting in Lua.</description>
-    <copyright>Copyright 2008-2025, Mudlet Makers</copyright>
+    <copyright>Copyright 2008-2026, Mudlet Makers</copyright>
     <tags>mud game rpg text</tags>
   </metadata>
 </package>


### PR DESCRIPTION
Companion change to https://github.com/Mudlet/Mudlet/pull/8727 .