### PR TITLE
Fix: remove linuxdeployqt bloat from AppImage

### DIFF
--- a/generic-linux/make-installer.sh
+++ b/generic-linux/make-installer.sh
@@ -138,6 +138,7 @@ echo "Generating AppImage"
 # Solution based on Nextcloud Desktop's approach:
 # https://github.com/nextcloud/desktop/blob/master/admin/linux/build-appimage.sh
 echo "Applying libglib workaround for password storage (#6730)..."
+rm -rf squashfs-root/
 TEMP_APPIMAGE=$(ls Mudlet*.AppImage)
 chmod +x "${TEMP_APPIMAGE}"
 ./"${TEMP_APPIMAGE}" --appimage-extract


### PR DESCRIPTION
The libglib workaround (#127) extracts the Mudlet AppImage into `squashfs-root/`, but that directory already exists from the earlier linuxdeployqt extraction. This merges ~77MB (uncompressed) of build tools (`appimagetool`, `linuxdeployqt`, `mksquashfs`, `patchelf`, `zsyncmake`, old Qt5/ICU libs) into the final AppImage.

Fix: clean up `squashfs-root/` before re-extracting.

Estimated to shrink the AppImage by ~31MB (from 135MB to ~104MB). The remaining increase over 4.19.1's 77MB is expected from the Qt6 migration:
- Qt6 Multimedia uses FFmpeg instead of GStreamer (libavcodec, libavformat, libavutil, libswresample, libswscale)
- ICU upgraded from 56 to 73
- New libraries: hunspell, assimp, OpenSSL 3, pugixml, opus, xcb utilities

Separately, there are also ~15MB of Qt6 QML/Quick libraries being bundled that Mudlet doesn't use - likely pulled in as transitive dependencies by linuxdeployqt.