### PR TITLE
Add lpeg for macos and linux

### DIFF
--- a/generic-linux/make-installer.sh
+++ b/generic-linux/make-installer.sh
@@ -84,7 +84,7 @@ mkdir -p build/lib/brimworks
 
 cp "$SOURCE_DIR"/3rdparty/discord/rpc/lib/libdiscord-rpc.so build/lib/
 
-for lib in lfs rex_pcre2 luasql/sqlite3 brimworks/zip lua-utf8 yajl
+for lib in lfs rex_pcre2 luasql/sqlite3 brimworks/zip lua-utf8 lpeg yajl
 do
   found=0
   for path in $(luarocks path --lr-cpath | tr ";" "\n")
@@ -126,6 +126,7 @@ echo "Generating AppImage"
 ./squashfs-root/AppRun ./build/mudlet -appimage \
   -executable=build/lib/rex_pcre2.so -executable=build/lib/zip.so \
   -executable=build/lib/luasql/sqlite3.so -executable=build/lib/yajl.so \
+  -executable=build/lib/lpeg.so \
   -executable=build/lib/libssl.so.1.1 \
   -executable=build/lib/libssl.so.1.0.0 \
   -extra-plugins=texttospeech/libqttexttospeech_flite.so,texttospeech/libqttexttospeech_speechd.so,platforminputcontexts/libcomposeplatforminputcontextplugin.so,platforminputcontexts/libibusplatforminputcontextplugin.so,platforminputcontexts/libfcitxplatforminputcontextplugin.so

--- a/osx/make-installer.sh
+++ b/osx/make-installer.sh
@@ -127,6 +127,8 @@ install_name_tool -change "${HOMEBREW_PREFIX}/opt/sqlite/lib/libsqlite3.dylib" "
 
 cp -v "${HOME}/.luarocks/lib/lua/5.1/lua-utf8.so" "${app}/Contents/MacOS"
 
+cp -v "${HOME}/.luarocks/lib/lua/5.1/lpeg.so" "${app}/Contents/MacOS"
+
 # The lua-zip rock
 mkdir "${app}/Contents/MacOS/brimworks"
 cp -v "${HOME}/.luarocks/lib/lua/5.1/brimworks/zip.so" "${app}/Contents/MacOS/brimworks" 


### PR DESCRIPTION
Mudlet already ships with lpeg [for windows](https://github.com/Mudlet/Mudlet/blob/ea57a6dc1c86aa12fdb87947e99da289c2de9db9/CI/package-mudlet-for-windows.sh#L160), this adds it for macos and linux as well.

This PR is a prerequisite for [this PR](https://github.com/Mudlet/Mudlet/pull/9212) in the main mudlet repo